### PR TITLE
Let the user configure more settings.

### DIFF
--- a/lib/cmake.js
+++ b/lib/cmake.js
@@ -8,6 +8,8 @@ import { execSync } from 'child_process';
 import voucher from 'voucher';
 import glob from 'glob';
 
+export const config = require('./config');
+
 export function providingFunction() {
     const generateErrorMatch = [
         "CMake Error at (?<file>[\\/0-9a-zA-Z\\._-]+):(?<line>\\d+)"
@@ -21,8 +23,7 @@ export function providingFunction() {
             super();
             this.source_dir = source_dir;
             // TODO allow the source directory to be selected.
-            // TODO allow the build directory to be selected.
-            this.build_dir = this.source_dir+"-build";
+            this.build_dir = this.source_dir + atom.config.get('build-cmake.build_suffix');
             this.cache_path = path.join(this.build_dir,'CMakeCache.txt');
         }
 
@@ -41,7 +42,7 @@ export function providingFunction() {
             return {
                 atomCommandName : 'cmake:'+target_name,
                 name : target_name,
-                exec : 'cmake',
+                exec : atom.config.get('build-cmake.executable'),
                 cwd : this.source_dir,
                 args : [ '--build', this.build_dir, '--target',target_name,'--','/maxcpucount','/clp:NoSummary;ErrorsOnly;Verbosity=quiet'],
                 errorMatch : compileErrorMatch.concat(generateErrorMatch),
@@ -58,9 +59,9 @@ export function providingFunction() {
 
         createMakeFileTarget(target_name) {
             return {
-                atomCommandName : 'cmake:'+target_name,
+                atomCommandName : 'cmake:' + target_name,
                 name : target_name,
-                exec : 'cmake',
+                exec : atom.config.get('build-cmake.executable'),
                 cwd : this.source_dir,
                 args : [ '--build', this.build_dir, '--target',target_name,'--','-j'+os.cpus().length],
                 errorMatch : compileErrorMatch.concat(generateErrorMatch),
@@ -69,7 +70,8 @@ export function providingFunction() {
         }
 
         makeFileTargets() {
-            output = execSync('cmake --build ' + this.build_dir + ' --target help' , { cwd: this.build_dir });
+            output = execSync(
+              atom.config.get('build-cmake.executable') + ' --build ' + this.build_dir + ' --target help', { cwd: this.build_dir });
             return output.toString('utf8')
             .split(/[\r\n]{1,2}/)
             .filter(line => line.startsWith('...'))
@@ -84,12 +86,18 @@ export function providingFunction() {
                     this.emit('refresh');
             });
 
+            args = ['-B' + this.build_dir, '-H' + this.source_dir, '-DCMAKE_EXPORT_COMPILE_COMMANDS=ON']
+            // Add custom generator if specified.
+            if (atom.config.get('build-cmake.generator') != "") {
+              // Todo: Validate generator on settings page (if possible)
+              args.unshift('-G' + atom.config.get('build-cmake.generator'))
+            }
             const generateTarget = {
                 atomCommandName : 'cmake:generate',
                 name : 'generate',
-                exec : 'cmake',
+                exec : atom.config.get('build-cmake.executable'),
                 cwd : this.source_dir,
-                args : ['-B'+this.build_dir,'-H'+this.source_dir,'-DCMAKE_EXPORT_COMPILE_COMMANDS=ON'],
+                args : args,
                 errorMatch:generateErrorMatch,
                 sh : false
             };

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,0 +1,25 @@
+'use babel';
+
+export default {
+  executable: {
+    title: 'Cmake Executable',
+    description: 'The path to the cmake executable.',
+    type: 'string',
+    default: 'cmake',
+    order: 1
+  },
+  generator: {
+    title: 'Generator',
+    description: 'The default cmake generator.',
+    type: 'string',
+    default: '',
+    order: 2
+  },
+  build_suffix: {
+    title: 'Build Location',
+    description: 'The build suffix appended to the source dir (may be a path location such as "/build").',
+    type: 'string',
+    default: '-build',
+    order: 3
+  }
+}


### PR DESCRIPTION
I needed to change the default settings, so I added config settings for the generator, the cmake executable path, and a "build suffix" (a string appended to the source dir to determine the build dir).  This is my first time with an atom package and I can't remember the last time I used javascript, so critique is welcome.

I should probably be flushing a cache somewhere when the user edits these settings.  I don't think they get refreshed unless the user restarts atom.  That was a bit more than I was ready to take on at the moment...
