### PR TITLE
Add setting for Visual Studio build arguments

### DIFF
--- a/lib/cmake.js
+++ b/lib/cmake.js
@@ -36,9 +36,13 @@ export function providingFunction() {
                 // TODO: Validate executable is on path/exists and show feedback to user.
                 this.executable = executable;
             });
+            atom.config.observe('build-cmake.vs_args', (args) => {
+              this.vs_args = args.split(' ');
+            });
             atom.config.onDidChange('build-cmake.build_suffix', () => {this.emit('refresh');});
             atom.config.onDidChange('build-cmake.executable', () => {this.emit('refresh');});
             atom.config.onDidChange('build-cmake.generator', () => {this.emit('refresh');});
+            atom.config.onDidChange('build-cmake.vs_args', () => {this.emit('refresh');});
         }
 
         destructor() {
@@ -58,7 +62,7 @@ export function providingFunction() {
                 name : target_name,
                 exec : this.executable,
                 cwd : this.source_dir,
-                args : [ '--build', this.build_dir, '--target',target_name,'--','/maxcpucount','/clp:NoSummary;ErrorsOnly;Verbosity=quiet'],
+                args : [ '--build', this.build_dir, '--target',target_name,'--'].concat(this.vs_args),
                 errorMatch : compileErrorMatch.concat(generateErrorMatch),
                 sh : false
             };

--- a/lib/config.js
+++ b/lib/config.js
@@ -21,5 +21,12 @@ export default {
     type: 'string',
     default: '-build',
     order: 3
+  },
+  vs_args: {
+    title: 'Visual Studio Build Arguments',
+    description: 'These build tool arguments are passed when building with Visual Studio.',
+    type: 'string',
+    default: '/maxcpucount /clp:NoSummary;ErrorsOnly;Verbosity=quiet',
+    order: 4
   }
 }


### PR DESCRIPTION
This change adds a new setting to configure the arguments passed to MSBuild when building with Visual Studio while keeping what was hard coded as the default (which was `/maxcpucount /clp:NoSummary;ErrorsOnly;Verbosity=quiet`).
