### PR TITLE
Added variables to the build location option

### DIFF
--- a/lib/cmake.js
+++ b/lib/cmake.js
@@ -8,10 +8,6 @@ import {execSync} from 'child_process';
 import voucher from 'voucher';
 import glob from 'glob';
 
-function initConfig() {
-
-}
-
 export const config = require('./config');
 
 export function providingFunction()

--- a/lib/cmake.js
+++ b/lib/cmake.js
@@ -8,6 +8,10 @@ import {execSync} from 'child_process';
 import voucher from 'voucher';
 import glob from 'glob';
 
+function initConfig() {
+
+}
+
 export const config = require('./config');
 
 export function providingFunction()
@@ -33,8 +37,45 @@ export function providingFunction()
             atom.config.observe('build-cmake.cmakelists', (cmakelists) => {
                 this.source_dir = (!!cmakelists) ? source_dir + cmakelists.trim() : source_dir;
             });
-            atom.config.observe('build-cmake.build_suffix', (suffix) => {
-                this.build_dir = source_dir + suffix;
+            atom.config.observe('build-cmake.build_dir', (buildDir) => {
+
+                const pathVars = {
+                    TMPDIR: os.tmpdir(),
+                    PROJECT_DIR: this.source_dir,
+                    PROJECT_DIRNAME: path.basename(this.source_dir)
+                };
+
+                // @TODO: Add escape for '$'
+                var pathVarNames = buildDir.match(/\$([a-zA-Z_]+)/g);
+
+                if(pathVarNames) {
+                    for(let i=0; pathVarNames.length > i; i++) {
+                        let pathVarName = pathVarNames[i];
+                        let pathVarNameWithoutPrefix = pathVarName.substr(1);
+                        let pathVarValue = pathVars[pathVarNameWithoutPrefix];
+
+                        if(!pathVarValue) {
+                            pathVarValue = "";
+                            // @TODO: Maybe include environment variables?
+                        }
+
+                        let pathVarMatch = new RegExp(
+                            "\\" + pathVarName
+                        );
+
+                        buildDir = buildDir.replace(
+                            pathVarMatch,
+                            pathVarValue
+                        );
+                    }
+                }
+
+                if(path.isAbsolute(buildDir)) {
+                    this.build_dir = path.normalize(buildDir);
+                } else {
+                    this.build_dir = path.resolve(source_dir, buildDir);
+                }
+
                 this.cache_path = path.join(this.build_dir, 'CMakeCache.txt');
             });
             atom.config.observe('build-cmake.generator', (generator) => {
@@ -54,7 +95,7 @@ export function providingFunction()
             atom.config.observe('build-cmake.parallel_build', (parallel_build) => {
                 this.parallel_build = parallel_build;
             });
-            atom.config.onDidChange('build-cmake.build_suffix', () => { this.emit('refresh'); });
+            atom.config.onDidChange('build-cmake.build_dir', () => { this.emit('refresh'); });
             atom.config.onDidChange('build-cmake.executable', () => { this.emit('refresh'); });
             atom.config.onDidChange('build-cmake.generator', () => { this.emit('refresh'); });
             atom.config.onDidChange('build-cmake.cmakelists', () => { this.emit('refresh'); });

--- a/lib/config.js
+++ b/lib/config.js
@@ -29,11 +29,17 @@ export default {
         default : ' -DCMAKE_BUILD_TYPE=Debug ',
         order : 4
     },
-    build_suffix : {
+    build_dir : {
         title : 'Build Location',
-        description : 'The build suffix appended to the source dir (may be a path location such as "/build").',
+        description :
+            'The build directory. The following variables can be used: '    +
+            ''                                                              +
+            '<br>`TMPDIR` - The operating system\'s default temp directory' +
+            '<br>`PROJECT_DIR` - Current project directory'                 +
+            '<br>`PROJECT_DIRNAME` - Current project directory name'        +
+            '<br> \n',
         type : 'string',
-        default : '-build',
+        default : '$PROJECT_DIR-build',
         order : 5
     },
     build_arguments : {


### PR DESCRIPTION
In my projects my build directory is outside of the source directory so I added variables to the build location instead of it being a suffix. The default option doesn't break with the old `build_suffix` but it is not compatible if you've changed it.

If you had `-build` as the value you'd now need to set it to `$PROJECT_DIR-build`. The variables that are available for the build location are in the description in the settings.