### PR TITLE
Added validation to executable and added generator list

### DIFF
--- a/lib/cmake.js
+++ b/lib/cmake.js
@@ -4,11 +4,15 @@ import EventEmitter from 'events';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import {execSync} from 'child_process';
+import {execSync, exec} from 'child_process';
 import voucher from 'voucher';
 import glob from 'glob';
 
-export const config = require('./config');
+import defaultConfig from "./config";
+export config from "./config";
+
+// Store this because the default schema will overwrite it
+var initialGeneratorValue = atom.config.get("build-cmake.generator");
 
 export function providingFunction()
 {
@@ -26,10 +30,14 @@ export function providingFunction()
         "(.+:\\d+:\\d+:\n)?(?<file>.+):(?<line>\\d+):(?<column>\\d+):\\s+(.*\\s+)?warning:\\s+(?<message>.+)", // GCC/Clang warning
         "(.*>)?(?<file>.+)\\((?<line>\\d+)\\):\\s+(.*\\s+)?warning\\s+(C\\d+):(?<message>.*)" // Visual Studio warning
     ];
+
     return class CMakeBuildProvider extends EventEmitter {
         constructor(source_dir)
         {
             super();
+            // Set default value of generator. Wihtout this errors overwrite
+            // the visual selection of the generator.
+            this.generator = atom.config.get("build-cmake.generator");
             atom.config.observe('build-cmake.cmakelists', (cmakelists) => {
                 this.source_dir = (!!cmakelists) ? source_dir + cmakelists.trim() : source_dir;
             });
@@ -38,12 +46,21 @@ export function providingFunction()
                 this.cache_path = path.join(this.build_dir, 'CMakeCache.txt');
             });
             atom.config.observe('build-cmake.generator', (generator) => {
-                // TODO: Validate generator exists and show feedback to user.
                 this.generator = (!!generator) ? generator.trim() : '';
             });
-            atom.config.observe('build-cmake.executable', (executable) => {
-                // TODO: Validate executable is on path/exists and show feedback to user.
-                this.executable = executable;
+            atom.config.observe('build-cmake.executable', executable => {
+                this.executable = executable.trim();
+
+                // Prevent any arguments since this could be exploited
+                let firstWhiteSpace = this.executable.search(/\s/);
+                if(firstWhiteSpace > -1) {
+                  this.executable = this.executable.substr(0, firstWhiteSpace);
+                }
+
+                // @TODO: Either set their executable without arguments or
+                //        give them an error message saying they cannot use
+                //        arguments.
+                // atom.config.set("build-cmake.executable", this.executable);
             });
             atom.config.observe('build-cmake.cmake_arguments', (args) => {
                 this.cmake_arguments = args.split(' ').filter(v => v !== '');
@@ -70,6 +87,166 @@ export function providingFunction()
         getNiceName()
         {
             return 'cmake';
+        }
+
+        getDefaultGenerator()
+        {
+            // @TODO: Determine the platforms default generator instead of the
+            //        first one in the list
+            return this.availableGenerators[0];
+        }
+
+        getGeneratorSelectElement()
+        {
+            return document.getElementById("build-cmake.generator");
+        }
+
+        setAvailableGenerators(generators)
+        {
+            let selectEl = this.getGeneratorSelectElement();
+            let currentGenerator = atom.config.get("build-cmake.generator");
+
+            if(selectEl) {
+
+                // Clear select element children.
+                while(selectEl.lastChild) {
+                  selectEl.lastChild.remove();
+                }
+
+                [""].concat(generators).forEach(generator => {
+                    let optionEl = document.createElement("option");
+                    optionEl.value = generator;
+                    optionEl.textContent = generator;
+
+                    selectEl.appendChild(optionEl);
+                });
+
+                // Clear above causes the selected value to disapear so we set
+                // it here.
+                selectEl.value = currentGenerator;
+            }
+
+            // Update schema with new enum values
+            atom.config.setSchema("build-cmake.generator", Object.assign(
+                defaultConfig.generator,
+                { enum: [''].concat(generators) }
+            ));
+
+            if(!currentGenerator) {
+              atom.config.set("build-cmake.generator", initialGeneratorValue);
+              // Clear this once we've set it.
+              initialGeneratorValue = "";
+            }
+
+            this.availableGenerators = generators;
+        }
+
+        setGeneratorSelectorError(msg) {
+          let selectEl = this.getGeneratorSelectElement();
+          let optionEl = document.createElement("option");
+          optionEl.value = "";
+          optionEl.textContent = msg;
+
+          while(selectEl.lastChild) {
+            selectEl.lastChild.remove();
+          }
+
+          selectEl.appendChild(optionEl);
+          selectEl.value = "";
+        }
+
+        validateExecutable()
+        {
+            let executable = this.executable;
+
+            function extractGenerators(stdout) {
+                let generatorNames = [];
+                let startIndex = stdout.search(/\s*Generators\s*(\r\n|\n)/);
+                if(startIndex === -1) {
+                  return false;
+                }
+
+                let generatorsStr = stdout.toString().substr(startIndex);
+                let colonIndex = generatorsStr.indexOf(':');
+
+                if(colonIndex === -1) {
+                  return false;
+                }
+
+                generatorsStr = generatorsStr.substring(colonIndex + 1);
+
+                let generatorsSplit = generatorsStr.split(/\n  (\w)/gi);
+
+                if(generatorsSplit[0].trim() == "") {
+                    generatorsSplit.shift();
+                }
+
+                for(let i=0; generatorsSplit.length > i; i+=2) {
+                    let generatorStr =
+                      generatorsSplit[i] + generatorsSplit[i+1];
+                    let generatorSplit = generatorStr.split("=");
+                    let generatorName = generatorSplit[0].trim();
+                    let generatorDesc = generatorSplit[1].trim();
+                    let genNameNoArch = generatorName.replace("[arch]", "");
+                    genNameNoArch = genNameNoArch.trim();
+
+                    generatorNames.push(genNameNoArch);
+
+                    if(generatorName.indexOf("[arch]") > -1) {
+                        let archIndex = generatorDesc.indexOf("[arch]");
+                        if(archIndex > -1) {
+                            let archs = generatorDesc.match(/"\S*"/gi);
+
+                            archs.forEach(arch => {
+                              arch = arch.substring(1, arch.length-1);
+                              generatorNames.push(genNameNoArch + " " + arch);
+                            });
+                        }
+                    }
+                }
+
+                return generatorNames;
+            }
+
+            return new Promise((resolve, reject) => {
+                exec(executable + " --help", (err, stdout, stderr) => {
+
+                  if(err) {
+                      this.setGeneratorSelectorError(
+                        `<ERROR: Failed to execute '${executable}'>`
+                      );
+                      return reject();
+                  }
+
+                  if(stdout.length === 0) {
+                      this.setGeneratorSelectorError(
+                        `<ERROR: '${executable}' produced empty stdout>`
+                      );
+                      return reject();
+                  }
+
+                  if(stderr.length > 0) {
+                      this.setGeneratorSelectorError(
+                        `<ERROR: Failed to execute '${executable}'>`
+                      );
+                      return reject();
+                  }
+
+                  let generators = extractGenerators(stdout);
+
+                  if(!generators) {
+                    this.setGeneratorSelectorError(
+                      `<ERROR: Invalid CMake executable '${executable}'>`
+                    );
+                    return reject();
+                  }
+
+                  this.setAvailableGenerators(generators);
+                  this.executable = executable;
+
+                  return resolve();
+                });
+            });
         }
 
         isEligible()
@@ -177,7 +354,12 @@ export function providingFunction()
                 sh : false
             };
 
-            return voucher(fs.readFile, this.cache_path, { encoding : 'utf8' })
+            return this.validateExecutable()
+                .then(() => {
+                    return voucher(fs.readFile, this.cache_path, {
+                        encoding : 'utf8'
+                    });
+                })
                 .then(cache => {
                     var generator = cache.match(/CMAKE_GENERATOR:INTERNAL=(.*)/)[1];
                     if (generator.match('Visual Studio'))

--- a/lib/config.js
+++ b/lib/config.js
@@ -20,7 +20,8 @@ export default {
         description : 'The default CMake generator.',
         type : 'string',
         default : '',
-        order : 3
+        order : 3,
+        enum: ['']
     },
     cmake_arguments : {
         title : 'Custom CMake Arguments',


### PR DESCRIPTION
You can now select your CMake generator via a list instead of typing out the exact name.
**Note:** I tried to follow your indentation (4 spaces) and if I missed any please let me know.

![build-cmake-settings](https://cloud.githubusercontent.com/assets/1284289/21537116/3e6b281e-cd41-11e6-8455-75e9164b4572.gif)
