### PR TITLE
Fix extraction of targets from ninja.

### DIFF
--- a/lib/cmake.js
+++ b/lib/cmake.js
@@ -356,7 +356,7 @@ export function providingFunction()
         ninjaTargets()
         {
             output = execSync(
-                this.executable + ' --build "' + this.build_dir + '" -- -t targets', { cwd : this.build_dir });
+                this.executable + ' --build "' + this.build_dir + '" -- -t query all', { cwd : this.build_dir });
             return output.toString('utf8')
                 .split(/[\r\n]{1,2}/)
                 .map((line) => this.createNinjaTarget(line.split(':')[0].trim()));


### PR DESCRIPTION
'-t targets' is not what one would expect, it shows only internal
targets. query all is much better:
```
[cbdhcp-2-244 Lunchbox threadpool]% ninja -C ../build/ -t targets  | grep voxelize
Fivox/apps/voxelize/install/local: phony
Fivox/apps/voxelize/install: phony
Fivox/apps/voxelize/test: phony
Fivox/apps/voxelize/rebuild_cache: phony
Fivox/apps/voxelize/package_source: phony
Fivox/apps/voxelize/install/strip: phony
Fivox/apps/voxelize/package: phony
Fivox/apps/voxelize/list_install_components: phony
Fivox/apps/voxelize/edit_cache: phony
Fivox/apps/voxelizeBatch/install/strip: phony
Fivox/apps/voxelizeBatch/install: phony
Fivox/apps/voxelizeBatch/list_install_components: phony
Fivox/apps/voxelizeBatch/install/local: phony
Fivox/apps/voxelizeBatch/test: phony
Fivox/apps/voxelizeBatch/package_source: phony
Fivox/apps/voxelizeBatch/rebuild_cache: phony
Fivox/apps/voxelizeBatch/edit_cache: phony
Fivox/apps/voxelizeBatch/package: phony
cpplint_run_voxelize: phony
voxelize-AppleCheckOpenGL: phony
voxelize-runcppcheck: phony
[cbdhcp-2-244 Lunchbox threadpool]% ninja -C ../build/ -t query all | grep voxelize
    bin/voxelize
[cbdhcp-2-244 Lunchbox threadpool]%
```

@tribal-tec FYI
