### PR TITLE
Improve extraction of targets from ninja:

### DIFF
--- a/lib/cmake.js
+++ b/lib/cmake.js
@@ -356,9 +356,19 @@ export function providingFunction()
         {
             output = execSync(
                 this.executable + ' --build "' + this.build_dir + '" -- -t query all', { cwd : this.build_dir });
-            return output.toString('utf8')
+            all = output.toString('utf8')
+                .split(/[\r\n]{1,2}/)
+                .filter(line => line.startsWith('    '))
+                .map((line) => this.createNinjaTarget(line.trim()))
+                .concat([this.createNinjaTarget('all')]);
+
+            output = execSync(
+                this.executable + ' --build "' + this.build_dir + '" -- -t targets', { cwd : this.build_dir });
+            targets = output.toString('utf8')
                 .split(/[\r\n]{1,2}/)
                 .map((line) => this.createNinjaTarget(line.split(':')[0].trim()));
+
+            return all.concat( targets );
         }
 
         settings()


### PR DESCRIPTION
ninja -t targets shows some targets from cmake, but is omitting a
lot. ninja -t query all shows all targets linked to the cmake "ALL"
target, but omits the non-default targets. Merge the two.

I'll probably submit iterations on this in the future, with better
filtering and extraction.